### PR TITLE
bump Junit to latest stable version 5.11.3

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,14 +3,12 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 object Libraries {
     internal object Versions {
         const val hamcrest = "2.2"
-        const val junit = "5.6.2"
         const val kotlin = "1.5.0"
         const val logback = "1.2.3"
     }
 
     const val hamcrest = "org.hamcrest:hamcrest:${Versions.hamcrest}"
     const val hamcrestLibrary = "org.hamcrest:hamcrest-library:${Versions.hamcrest}"
-    const val junitApi = "org.junit.jupiter:junit-jupiter-api:${Versions.junit}"
     const val kotlinReflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}"
 }
 
@@ -21,7 +19,6 @@ object TestLibraries {
 
     const val hamcrest = Libraries.hamcrest
     const val hamcrestLibrary = Libraries.hamcrestLibrary
-    const val junitJupiter = "org.junit.jupiter:junit-jupiter:${Libraries.Versions.junit}"
     const val kotestRunner = "io.kotest:kotest-runner-junit5-jvm:${Versions.kotest}"
     const val kotestProperty = "io.kotest:kotest-property:${Versions.kotest}"
     const val kotestAssert = "io.kotest:kotest-assertions-core:${Versions.kotest}"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,8 +7,9 @@ plugins {
 }
 
 dependencies {
+    api(platform(libs.junit.bom))
     implementation(kotlin("stdlib-jdk8"))
-    testImplementation(TestLibraries.junitJupiter)
+    testImplementation(libs.junit.jupiter)
     testImplementHamcrest()
     testImplementation(TestLibraries.kotlinReflect)
     testImplementKotest()

--- a/java-demo/build.gradle.kts
+++ b/java-demo/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 dependencies {
+    api(platform(libs.junit.bom))
     implementation(libs.slf4j)
     implementation(libs.logback.classic)
     implementation(libs.logback.core)
@@ -14,7 +15,7 @@ dependencies {
     testImplementation(project(":hamcrest-support"))
     testImplementation(project(":slf4j-logback"))
     testImplementHamcrest()
-    testImplementation(TestLibraries.junitJupiter)
+    testImplementation(libs.junit.jupiter)
 }
 
 tasks.test { configure<JacocoTaskExtension> { isEnabled = false } }

--- a/junit5-support/build.gradle.kts
+++ b/junit5-support/build.gradle.kts
@@ -7,10 +7,11 @@ plugins {
 }
 
 dependencies {
+    api(platform(libs.junit.bom))
     implementation(project(":core"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation(Libraries.junitApi)
-    testImplementation(TestLibraries.junitJupiter)
+    implementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter)
     testImplementHamcrest()
     testImplementation(TestLibraries.kotlinReflect)
     testImplementKotest()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,9 @@ dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
             plugin("ktlint", "org.jlleitschuh.gradle.ktlint").version("12.1.1")
+            library("junit-bom", "org.junit", "junit-bom").version("5.11.3")
+            library("junit-jupiter-api", "org.junit.jupiter", "junit-jupiter-api").withoutVersion()
+            library("junit-jupiter", "org.junit.jupiter", "junit-jupiter").withoutVersion()
             version("logback", "1.3.14")
             library("logback-core", "ch.qos.logback", "logback-core").versionRef("logback")
             library("logback-classic", "ch.qos.logback", "logback-classic").versionRef("logback")

--- a/slf4j-logback/build.gradle.kts
+++ b/slf4j-logback/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 }
 
 dependencies {
+    api(platform(libs.junit.bom))
     implementation(project(":core"))
     implementation(kotlin("stdlib-jdk8"))
     implementation(libs.slf4j)
@@ -14,7 +15,7 @@ dependencies {
     implementation(libs.logback.core)
     testImplementation(project(":testing"))
     testImplementation(project(":hamcrest-support"))
-    testImplementation(TestLibraries.junitJupiter)
+    testImplementation(libs.junit.jupiter)
     testImplementHamcrest()
     testImplementKotest()
 }

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -4,11 +4,12 @@ plugins {
 }
 
 dependencies {
+    api(platform(libs.junit.bom))
     implementation(project(":core"))
     implementation(project(":junit5-support"))
     implementation(kotlin("stdlib-jdk8"))
     implementation(project(":hamcrest-support"))
-    implementation(TestLibraries.junitJupiter)
+    implementation(libs.junit.jupiter)
     implementation(TestLibraries.hamcrest)
     implementation(TestLibraries.hamcrestLibrary)
     implementation(libs.slf4j)


### PR DESCRIPTION
This commit also migrates the version definition into a catalogue file and makes use of Junit's BOM.